### PR TITLE
improve process matching

### DIFF
--- a/dist/vesktopCustomCommands/deafen.sh
+++ b/dist/vesktopCustomCommands/deafen.sh
@@ -2,16 +2,16 @@
 
 # Normalize a path by replacing ~ with $HOME
 normalizePath() {
-    local input_path="$1"
+  local input_path="$1"
 
-    # Check if the path starts with ~
-    if [[ "$input_path" == ~* ]]; then
-        # Replace ~ with $HOME
-        echo "${input_path/#\~/$HOME}"
-    else
-        # Return the path as is if it does not start with ~
-        echo "$input_path"
-    fi
+  # Check if the path starts with ~
+  if [[ "$input_path" == ~* ]]; then
+    # Replace ~ with $HOME
+    echo "${input_path/#\~/$HOME}"
+  else
+    # Return the path as is if it does not start with ~
+    echo "$input_path"
+  fi
 }
 
 # Define the base directory
@@ -21,39 +21,40 @@ VENCORD_PATH="$DEFAULT_BASE_DIR"
 # Read .config file to get the Vencord path
 CONFIG_FILE="$(dirname "$0")/.config"
 if [ -f "$CONFIG_FILE" ]; then
-    source "$CONFIG_FILE"
-    VENCORD_PATH="$(normalizePath "$vencord_path")"
-    echo "Vencord path set to: $VENCORD_PATH"
+  source "$CONFIG_FILE"
+  VENCORD_PATH="$(normalizePath "$vencord_path")"
+  echo "Vencord path set to: $VENCORD_PATH"
 fi
 
 # Check if the path ends with a slash, if not, add it
 if [[ "$VENCORD_PATH" != */ ]]; then
-    VENCORD_PATH="${VENCORD_PATH}/"
+  VENCORD_PATH="${VENCORD_PATH}/"
 fi
 
 FULL_DIR="${VENCORD_PATH}vesktopCustomCommands"
 
 # Check if Vesktop is running
-VESKTOP_PIDS=$(pgrep -af "dev.vencord.Vesktop" | awk '{print $1}')
+VESKTOP_PIDS=$(pgrep -af "(dev\.vencord\.)?vesktop" | awk '{print $1}')
 
 if [ -n "$VESKTOP_PIDS" ]; then
-    # Vesktop is active, create the mute file
-    DEAFEN_FILE="$FULL_DIR/deafen"
+  # Vesktop is active, create the mute file
+  DEAFEN_FILE="$FULL_DIR/deafen"
 
-    # Create the directory if it does not exist
-    mkdir -p "$FULL_DIR"
+  # Create the directory if it does not exist
+  mkdir -p "$FULL_DIR"
 
-    # Create the mute file
-    touch "$DEAFEN_FILE"
+  # Create the mute file
+  touch "$DEAFEN_FILE"
 
-    # Check if the file was created successfully
-    if [ -f "$DEAFEN_FILE" ]; then
-        echo "File 'deafen' created successfully at: $DEAFEN_FILE"
-    else
-        echo "Error: Unable to create the 'deafen' file."
-        exit 1
-    fi
-else
-    echo "Error: Vesktop is not running. The 'deafen' file will not be created."
+  # Check if the file was created successfully
+  if [ -f "$DEAFEN_FILE" ]; then
+    echo "File 'deafen' created successfully at: $DEAFEN_FILE"
+  else
+    echo "Error: Unable to create the 'deafen' file."
     exit 1
+  fi
+else
+  echo "Error: Vesktop is not running. The 'deafen' file will not be created."
+  exit 1
 fi
+

--- a/dist/vesktopCustomCommands/deafen.sh
+++ b/dist/vesktopCustomCommands/deafen.sh
@@ -34,7 +34,7 @@ fi
 FULL_DIR="${VENCORD_PATH}vesktopCustomCommands"
 
 # Check if Vesktop is running
-VESKTOP_PIDS=$(pgrep -af "(dev\.vencord\.)?vesktop" | awk '{print $1}')
+VESKTOP_PIDS=$(pgrep -aif "(dev\.vencord\.)?vesktop" | awk '{print $1}')
 
 if [ -n "$VESKTOP_PIDS" ]; then
   # Vesktop is active, create the mute file
@@ -57,4 +57,3 @@ else
   echo "Error: Vesktop is not running. The 'deafen' file will not be created."
   exit 1
 fi
-

--- a/dist/vesktopCustomCommands/mute.sh
+++ b/dist/vesktopCustomCommands/mute.sh
@@ -34,7 +34,7 @@ fi
 FULL_DIR="${VENCORD_PATH}vesktopCustomCommands"
 
 # Check if Vesktop is running
-VESKTOP_PIDS=$(pgrep -af '(dev\.vencord\.)?vesktop' | awk '{print $1}')
+VESKTOP_PIDS=$(pgrep -aif '(dev\.vencord\.)?vesktop' | awk '{print $1}')
 
 if [ -n "$VESKTOP_PIDS" ]; then
   # Vesktop is active, create the mute file
@@ -57,4 +57,3 @@ else
   echo "Error: Vesktop is not running. The 'mute' file will not be created."
   exit 1
 fi
-

--- a/dist/vesktopCustomCommands/mute.sh
+++ b/dist/vesktopCustomCommands/mute.sh
@@ -2,16 +2,16 @@
 
 # Normalize a path by replacing ~ with $HOME
 normalizePath() {
-    local input_path="$1"
+  local input_path="$1"
 
-    # Check if the path starts with ~
-    if [[ "$input_path" == ~* ]]; then
-        # Replace ~ with $HOME
-        echo "${input_path/#\~/$HOME}"
-    else
-        # Return the path as is if it does not start with ~
-        echo "$input_path"
-    fi
+  # Check if the path starts with ~
+  if [[ "$input_path" == ~* ]]; then
+    # Replace ~ with $HOME
+    echo "${input_path/#\~/$HOME}"
+  else
+    # Return the path as is if it does not start with ~
+    echo "$input_path"
+  fi
 }
 
 # Define the base directory
@@ -21,39 +21,40 @@ VENCORD_PATH="$DEFAULT_BASE_DIR"
 # Read .config file to get the Vencord path
 CONFIG_FILE="$(dirname "$0")/.config"
 if [ -f "$CONFIG_FILE" ]; then
-    source "$CONFIG_FILE"
-    VENCORD_PATH="$(normalizePath "$vencord_path")"
-    echo "Vencord path set to: $VENCORD_PATH"
+  source "$CONFIG_FILE"
+  VENCORD_PATH="$(normalizePath "$vencord_path")"
+  echo "Vencord path set to: $VENCORD_PATH"
 fi
 
 # Check if the path ends with a slash, if not, add it
 if [[ "$VENCORD_PATH" != */ ]]; then
-    VENCORD_PATH="${VENCORD_PATH}/"
+  VENCORD_PATH="${VENCORD_PATH}/"
 fi
 
 FULL_DIR="${VENCORD_PATH}vesktopCustomCommands"
 
 # Check if Vesktop is running
-VESKTOP_PIDS=$(pgrep -af "dev.vencord.Vesktop" | awk '{print $1}')
+VESKTOP_PIDS=$(pgrep -af '(dev\.vencord\.)?vesktop' | awk '{print $1}')
 
 if [ -n "$VESKTOP_PIDS" ]; then
-    # Vesktop is active, create the mute file
-    MUTE_FILE="$FULL_DIR/mute"
+  # Vesktop is active, create the mute file
+  MUTE_FILE="$FULL_DIR/mute"
 
-    # Create the directory if it does not exist
-    mkdir -p "$FULL_DIR"
+  # Create the directory if it does not exist
+  mkdir -p "$FULL_DIR"
 
-    # Create the mute file
-    touch "$MUTE_FILE"
+  # Create the mute file
+  touch "$MUTE_FILE"
 
-    # Check if the file was created successfully
-    if [ -f "$MUTE_FILE" ]; then
-        echo "File 'mute' created successfully at: $MUTE_FILE"
-    else
-        echo "Error: Unable to create the 'mute' file."
-        exit 1
-    fi
-else
-    echo "Error: Vesktop is not running. The 'mute' file will not be created."
+  # Check if the file was created successfully
+  if [ -f "$MUTE_FILE" ]; then
+    echo "File 'mute' created successfully at: $MUTE_FILE"
+  else
+    echo "Error: Unable to create the 'mute' file."
     exit 1
+  fi
+else
+  echo "Error: Vesktop is not running. The 'mute' file will not be created."
+  exit 1
 fi
+


### PR DESCRIPTION
If your vesktop is installed as a native package (for example, [CachyOS](https://packages.cachyos.org/package/cachyos/x86_64/vesktop)) then the process name would be just "vesktop", so the full path should be optional.